### PR TITLE
Replaced std::mem::size_of_val(&cpuset) with std::mem::size_of::<libc::cpu_set_t>(); Minimized an unsafe block

### DIFF
--- a/src/high_performance.rs
+++ b/src/high_performance.rs
@@ -818,13 +818,13 @@ pub fn pin_to_core(core_id: usize) -> Result<(), String> {
     // For now, we'll just document the pattern
     #[cfg(target_os = "linux")]
     {
-        unsafe {
+        let result = unsafe {
             let mut cpuset: libc::cpu_set_t = std::mem::zeroed();
             libc::CPU_SET(core_id, &mut cpuset);
-            let result = libc::sched_setaffinity(0, std::mem::size_of_val(&cpuset), &cpuset);
-            if result != 0 {
-                return Err(format!("Failed to set CPU affinity: {}", result));
-            }
+            libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &cpuset)
+        };
+        if result != 0 {
+            return Err(format!("Failed to set CPU affinity: {}", result));
         }
     }
 


### PR DESCRIPTION
Hi/Cześć Kamil or friend,

Thank you for `grpc_graphql_gateway`.

## Type of change

Minor: Code improvement.

Replacement of `std::mem::size_of_val` with `std::mem::size_of` is (in this instance) OK, since the type is not dynamically sized. See https://doc.rust-lang.org/std/mem/fn.size_of_val.html.

# How Has This Been Tested?

`cargo test` passed on modern 64-bit Linux, current stable Rust.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes