### PR TITLE
Removed unnecessary unsafe impl of Send and Sync

### DIFF
--- a/src/high_performance.rs
+++ b/src/high_performance.rs
@@ -493,9 +493,6 @@ impl<V: Clone + Send + Sync> ShardedCache<V> {
     }
 }
 
-unsafe impl<V: Clone + Send + Sync> Send for ShardedCache<V> {}
-unsafe impl<V: Clone + Send + Sync> Sync for ShardedCache<V> {}
-
 // =============================================================================
 // Object Pool
 // =============================================================================

--- a/src/high_performance.rs
+++ b/src/high_performance.rs
@@ -352,6 +352,16 @@ impl CacheStats {
     }
 }
 
+#[test]
+fn ensure_sharded_cache_is_sync_and_send() {
+    fn take_send_ref(_: &impl Send) {}
+    fn take_sync_ref(_: &impl Sync) {}
+    fn _take_sharded_cache<V: Clone + Send + Sync>(cache_ref: &ShardedCache<V>) {
+        take_send_ref(cache_ref);
+        take_sync_ref(cache_ref);
+    }
+}
+
 impl<V: Clone + Send + Sync> ShardedCache<V> {
     /// Create a new sharded cache
     pub fn new(num_shards: usize, max_entries_per_shard: usize) -> Self {


### PR DESCRIPTION
Hi Kamil,

1. I didn't check your GIT commits history, but I believe that initially you may have had `ShardedCache` defined as `pub struct ShardedCache<V> {...`, or `pub struct ShardedCache<V: Clone> {...` as that is, without `V` being bound by `Send+Sync`; but later you changed it to include `V` to be bound by `Send+Sync?

Either way, good learning: While having a struct/enum/union defined with the least restricting bounds is a common and recommended practice, unfortunately, it doesn't auto infer `Send` and `Sync`, hence there would be a need for `unsafe impl`. But since the `ShardedCache` does have `Send+Sync` bound on `V`, `Send` and `Sync` *are* auto-inferred.

2. The second commit in this PR adds a "test" that `ShardedCache` is indeed `Sync+Send`. I do NOT think that such a test is necessary, but if you do want to include it, do so. Maybe you had `unsafe impl` so that it would be clear/"guaranteed" that `Send` and `Sync` were intentional. This test could indicate it instead.

But, if you don't add this test, then `Send` and `Sync` are required by other parts of the code. For example, when I changed `ShardedCache` NOT to make it `Send+Sync` by (shortened `git diff` here):
```
pub struct ShardedCache<V: Clone + Send + Sync> {
     shards: Vec<CacheShard<V>>,
     shard_mask: usize,
     stats: CacheStats,
+    rc: Option<std::rc::Rc<()>>
 }
```
(and I've modified the `new` constructor accordingly), then many other parts of the code failed to build, like:
```
error: future cannot be sent between threads safely
    --> src/runtime.rs:1156:10
     |
1156 |         .on_upgrade(move |socket| handle_live_socket(socket, mux))
     |          ^^^^^^^^^^ future returned by `handle_live_socket` is not `Send`
```

So, it should be clear to anyone that `Send+Sync` is intentional.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
